### PR TITLE
Rate limit RCS messages

### DIFF
--- a/evgp_rcs/tcpserver.py
+++ b/evgp_rcs/tcpserver.py
@@ -5,6 +5,7 @@ import sys
 import re
 import time
 import logging
+import time
 from race import RaceState
 
 
@@ -128,7 +129,6 @@ class TCPServer(QObject):
                             pass
 
             for s in writable:
-                #TODO: some time processing so we don't send repeat signal too fast
                 try:
                     (addr, port) = s.getpeername()
                     state = self.states[addr]
@@ -136,6 +136,8 @@ class TCPServer(QObject):
                     s.send(msg.encode('utf-8'))
                 except OSError:
                     self.remove_lost_client(s)
+            #maybe make this configurable?
+            time.sleep(0.01)
         self.close_server()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "evgp-rcs"
 version = "0.1.0"
 description = ""
-authors = ["Brian Cochran Github @btdubs"]
+authors = ["Brian Cochran <placeholder@email.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This PR just adds a `time.sleep()` to the TCP server run loop. I don't think this will be an issue because the server already runs on a different thread, but correct me if I'm wrong. 

Currently the RCS spams us with messages as fast as it can iterate through the loop. In our client iteration, I have a loop that reads the TCP socket into a 1024 byte buffer every tenth of a second. The problem is, when I make our `recv` call, all 1024 bytes of buffer is taken up by `$IN_GARAGE;` messages. We think that the messages are piling up in a kernel buffer faster than our client can read them, since in the next iteration of the loop the `recv` call picks up right where the last buffer ended. The actual problematic part is that when the RCS starts sending a new command, our kart has to go through all the previous messages with the old command at only 10 KB/s, which takes a very long time. 

If there's a way to read the socket from the end of the kernel buffer instead of the beginning, that would fix our problem. However, I couldn't find a way to do that. 

The problem is fixed by also running our client's loop as fast as possible, but this isn't ideal because 1) it results in very high CPU usage and 2) it may be problematic when the server and the client are running on different computers with different speeds (I haven't tested this, however). 

However, everything works when a small delay (the delay in the PR is 10ms) is added.

~~PS
I have a commit in there that changes the formatting of the author string in `pyproject.toml` (fixes issue #7). If you want me to revert that or change it, let me know.~~
Merged the upstream fix