### PR TITLE
Rate limit server sending commands

### DIFF
--- a/evgp_rcs/gui.py
+++ b/evgp_rcs/gui.py
@@ -247,8 +247,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.is_server_started = True
             port = 12017
             server_backlog = 10
+            send_hz = 10
             ip_list = self.model.teams_list.keys()
-            self.server = TCPServer(port, server_backlog, whitelist=ip_list)
+            self.server = TCPServer(port, server_backlog, whitelist=ip_list, hz=send_hz)
             self.server.new_connection.connect(self.model.new_connection_handler)
             self.server.lost_connection.connect(self.model.lost_connection_handler)
             self.server.new_response.connect(self.model.new_response_handler)

--- a/evgp_rcs/tcpclient.py
+++ b/evgp_rcs/tcpclient.py
@@ -28,6 +28,8 @@ class TCPClient:
         self.last_msg = ""
         self.leftover_message = ""
 
+        self.last_receive_time = time.time()
+
     def receive_message(self):
         data = self.sock .recv(256)
         amount_received = len(data)
@@ -45,6 +47,9 @@ class TCPClient:
                 #print(data.decode('utf-8'))
                 pass
             else:
+                current_time = time.time()
+                self.time_between_messages = current_time - self.last_receive_time
+                self.last_receive_time = current_time
                 msg = matches[-1]
                 if msg != self.last_msg:
                     print(f"received {msg}")
@@ -58,6 +63,9 @@ class TCPClient:
             msg = f"{self.START_CHAR}{msg}{self.END_CHAR}"
             self.sock.sendall(msg.encode('utf-8'))
             print(f"sent {msg}")
+
+    def get_receive_hz(self):
+        return 1.0 / self.time_between_messages
 
     def close(self):
         self.sock.close()


### PR DESCRIPTION
* sets rate limit on server send commands
* adds receive hz to tcpclient for debugging

Server was sending things too fast. Now it is limited in sending to the TCPServer's set Hz rate. Defaults to 10 hz. Uses elapsed time check so that we can still read messages from clients quickly.

Note that the server is set to still run as fast as possible to handle all user messages. It takes 100% of a core on my machine. This should be fine for now, but we should add client rate limiting to the specification. Using select for more event based handling in the future would be nice.